### PR TITLE
fix: change type to module

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.1",
   "description": "A client side JavaScript image compression library",
   "main": "src/index.js",
-  "type": "commonjs",
+  "type": "module",
   "scripts": {
     "dev": "webpack --watch",
     "build": "webpack"


### PR DESCRIPTION
Allow compress.js to be bundled with Webpack 5, as now Webpack strictly prohibits usage of import and export in commonjs modules.
https://github.com/webpack/webpack/issues/11597#issuecomment-705467692
https://webpack.js.org/api/module-methods/

#13 